### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/tryexceptpass/sofi.png?label=ready&title=Ready)](https://waffle.io/tryexceptpass/sofi)
 ## Overview
 `sofi` is an OS agnostic UI module for Python.
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/tryexceptpass/sofi

This was requested by a real person (user tryexceptpass) on waffle.io, we're not trying to spam you.