### PR TITLE
fix: Added a shortcut for generating tag attributes (#73)

### DIFF
--- a/sofi/ui/element.py
+++ b/sofi/ui/element.py
@@ -35,10 +35,15 @@ class Element(object):
         output = []
 
         for name, as_html in attributes:
-            # Grab the value of the `name` attribute from `self`
-            value = getattr(self, name, None)
-            if value:
-                output.append('{}="{}"'.format(as_html, value))
+            if as_html is None:
+                # This is an attribute with no value
+                # e.g. <input type="text" name="name" value="" disabled>
+                output.append(name)
+            else:
+                # Grab the value of the `name` attribute from `self`
+                value = getattr(self, name, None)
+                if value:
+                    output.append('{}="{}"'.format(as_html, value))
 
         return ' '.join(output)
 

--- a/sofi/ui/element.py
+++ b/sofi/ui/element.py
@@ -28,6 +28,10 @@ class Element(object):
 
         If no arguments are given, `attributes` defaults to 
         `[('cl','class'), ('ident', 'id')]`.
+
+        If `attributes` contains a pair of ("some_name", None), `some_name`
+        will be taken as an attribute with no value and will be appended
+        directly to the output string.
         """
         if attributes is None:
             attributes=[('cl','class'), ('ident', 'id')]

--- a/sofi/ui/element.py
+++ b/sofi/ui/element.py
@@ -26,6 +26,8 @@ class Element(object):
         >>> e._attrs_to_string(attributes)
         'class="container" id="foo"'
 
+        If no arguments are given, `attributes` defaults to 
+        `[('cl','class'), ('ident', 'id')]`.
         """
         if attributes is None:
             attributes=[('cl','class'), ('ident', 'id')]

--- a/sofi/ui/element.py
+++ b/sofi/ui/element.py
@@ -12,6 +12,30 @@ class Element(object):
 
         self.children = list()
 
+    def _element_attributes(self, attributes):
+        """
+        A shortcut for generating all the tag attributes (id, class, etc) 
+        given a list of (attr_name_in_self, attr_name_in_html) pairs.
+
+        >>> e = Element(cl='container', ident='foo')
+
+        >>> attributes = [
+        ...         ('cl', 'class'),
+        ...         ('ident', 'id')]
+
+        >>> e._element_attributes(attributes)
+        'class="container" id="foo"'
+
+        """
+        output = []
+
+        for name, as_html in attributes:
+            # Grab the value of the `name` attribute from `self`
+            value = getattr(self, name)
+            if value:
+                output.append('{}="{}"'.format(as_html, value))
+
+        return ' '.join(output)
 
     def __repr__(self):
         return str(self)

--- a/sofi/ui/element.py
+++ b/sofi/ui/element.py
@@ -31,7 +31,7 @@ class Element(object):
 
         for name, as_html in attributes:
             # Grab the value of the `name` attribute from `self`
-            value = getattr(self, name)
+            value = getattr(self, name, None)
             if value:
                 output.append('{}="{}"'.format(as_html, value))
 

--- a/sofi/ui/element.py
+++ b/sofi/ui/element.py
@@ -12,7 +12,7 @@ class Element(object):
 
         self.children = list()
 
-    def _attrs_to_string(self, attributes):
+    def _attrs_to_string(self, attributes=None):
         """
         A shortcut for generating all the tag attributes (id, class, etc) 
         given a list of (attr_name_in_self, attr_name_in_html) pairs.
@@ -27,6 +27,9 @@ class Element(object):
         'class="container" id="foo"'
 
         """
+        if attributes is None:
+            attributes=[('cl','class'), ('ident', 'id')]
+
         output = []
 
         for name, as_html in attributes:

--- a/sofi/ui/element.py
+++ b/sofi/ui/element.py
@@ -12,7 +12,7 @@ class Element(object):
 
         self.children = list()
 
-    def _element_attributes(self, attributes):
+    def _attrs_to_string(self, attributes):
         """
         A shortcut for generating all the tag attributes (id, class, etc) 
         given a list of (attr_name_in_self, attr_name_in_html) pairs.
@@ -23,7 +23,7 @@ class Element(object):
         ...         ('cl', 'class'),
         ...         ('ident', 'id')]
 
-        >>> e._element_attributes(attributes)
+        >>> e._attrs_to_string(attributes)
         'class="container" id="foo"'
 
         """

--- a/test/element_test.py
+++ b/test/element_test.py
@@ -1,23 +1,23 @@
 from sofi.ui import Element
 
 
-def test_element_attributes_shortcut():
+def test_attrs_to_string_shortcut():
     attributes = [
             ('cl', 'class'),
             ('ident', 'id'),
             ]
     e = Element(cl='container', ident='foo')
     should_be = 'class="container" id="foo"'
-    assert e._element_attributes(attributes) == should_be
+    assert e._attrs_to_string(attributes) == should_be
 
-def test_element_attributes_empty_shortcut():
+def test_attrs_to_string_empty_shortcut():
     attributes = [
             ]
     e = Element()
     should_be = ''
-    assert e._element_attributes(attributes) == should_be
+    assert e._attrs_to_string(attributes) == should_be
 
-def test_element_attributes_with_nonexistent_attribute():
+def test_attrs_to_string_with_nonexistent_attribute():
     attributes = [
             ('cl', 'class'),
             ('ident', 'id'),
@@ -25,4 +25,4 @@ def test_element_attributes_with_nonexistent_attribute():
             ]
     e = Element(cl='container', ident='foo')
     should_be = 'class="container" id="foo"'
-    assert e._element_attributes(attributes) == should_be
+    assert e._attrs_to_string(attributes) == should_be

--- a/test/element_test.py
+++ b/test/element_test.py
@@ -25,6 +25,17 @@ def test_attrs_to_string_default_arguments():
     assert e._attrs_to_string() == should_be
 
 
+def test_attrs_to_string_attribute_with_no_value():
+    attributes = [
+            ('cl', 'class'),
+            ('ident', 'id'),
+            ('disabled', None),
+            ]
+    e = Element(cl='container', ident='foo')
+    should_be = 'class="container" id="foo" disabled'
+    assert e._attrs_to_string(attributes) == should_be
+
+
 def test_attrs_to_string_with_nonexistent_attribute():
     attributes = [
             ('cl', 'class'),

--- a/test/element_test.py
+++ b/test/element_test.py
@@ -17,3 +17,12 @@ def test_element_attributes_empty_shortcut():
     should_be = ''
     assert e._element_attributes(attributes) == should_be
 
+def test_element_attributes_with_nonexistent_attribute():
+    attributes = [
+            ('cl', 'class'),
+            ('ident', 'id'),
+            ('this_doesnt_exist', 'foo'),
+            ]
+    e = Element(cl='container', ident='foo')
+    should_be = 'class="container" id="foo"'
+    assert e._element_attributes(attributes) == should_be

--- a/test/element_test.py
+++ b/test/element_test.py
@@ -10,12 +10,20 @@ def test_attrs_to_string_shortcut():
     should_be = 'class="container" id="foo"'
     assert e._attrs_to_string(attributes) == should_be
 
+
 def test_attrs_to_string_empty_shortcut():
     attributes = [
             ]
     e = Element()
     should_be = ''
     assert e._attrs_to_string(attributes) == should_be
+
+
+def test_attrs_to_string_default_arguments():
+    e = Element(cl='container', ident='foo')
+    should_be = 'class="container" id="foo"'
+    assert e._attrs_to_string() == should_be
+
 
 def test_attrs_to_string_with_nonexistent_attribute():
     attributes = [

--- a/test/element_test.py
+++ b/test/element_test.py
@@ -1,0 +1,19 @@
+from sofi.ui import Element
+
+
+def test_element_attributes_shortcut():
+    attributes = [
+            ('cl', 'class'),
+            ('ident', 'id'),
+            ]
+    e = Element(cl='container', ident='foo')
+    should_be = 'class="container" id="foo"'
+    assert e._element_attributes(attributes) == should_be
+
+def test_element_attributes_empty_shortcut():
+    attributes = [
+            ]
+    e = Element()
+    should_be = ''
+    assert e._element_attributes(attributes) == should_be
+


### PR DESCRIPTION
* Added a modified version of the one in the issue
* Wrote some tests in a new `test/element_test.py` file
* Also added an example/doctest as part of the docstring for the
  `_element_attributes()` function