### PR TITLE
Use proper list method for callback removal

### DIFF
--- a/sofi/app/app.py
+++ b/sofi/app/app.py
@@ -122,7 +122,7 @@ class SofiEventProcessor(object):
         if selector is None:
             self.handlers[event]['_'].remove(callback)
         else:
-            self.handlers[event].pop(str(id(callback)))
+            self.handlers[event].get(str(id(callback)), []).remove(callback)
 
         if event not in ('init', 'load', 'close'):
             self.dispatch({ 'name': 'unsubscribe', 'event': event, 'selector': selector, 'key': str(id(callback)) })

--- a/sofi/app/app.py
+++ b/sofi/app/app.py
@@ -122,7 +122,9 @@ class SofiEventProcessor(object):
         if selector is None:
             self.handlers[event]['_'].remove(callback)
         else:
-            self.handlers[event].get(str(id(callback)), []).remove(callback)
+            handler_list = self.handlers[event].get(str(id(callback)), [])
+            if callback in handler_list:
+                handler_list.remove(callback)
 
         if event not in ('init', 'load', 'close'):
             self.dispatch({ 'name': 'unsubscribe', 'event': event, 'selector': selector, 'key': str(id(callback)) })


### PR DESCRIPTION
Fixes #83 
Handlers are stored in a `list` if a selector is given.  The `unregister()` method now functions as expected from tests created in a [separate branch](https://github.com/nocarryr/sofi/tree/callback-ids) of my fork.