### PR TITLE
Multi client support

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -131,4 +131,4 @@ app.register('init', oninit)
 app.register('load', onload)
 # app.register('click', clicked)
 
-app.start(False)
+app.start()

--- a/sample.py
+++ b/sample.py
@@ -83,7 +83,7 @@ async def oninit(event):
 
     v.addelement(c)
 
-    app.load(str(v))
+    app.load(str(v), event['client'])
 
 
 async def onload(event):
@@ -94,7 +94,7 @@ async def onload(event):
     await asyncio.sleep(5)
 
     for i in range(1, 5):
-        app.style("#fiddle", 'font-size', str(i*2) + "em", 'important')
+        app.style("#fiddle", 'font-size', str(i*2) + "em", 'important', event['client'])
 
         await asyncio.sleep(1)
 
@@ -103,14 +103,14 @@ async def onload(event):
     img = Image()
     img.datauri(os.path.join(os.path.dirname(__file__), 'test', 'test.png'))
 
-    app.replace("#fiddle", str(img))
+    app.replace("#fiddle", str(img), event['client'])
 
     msg = 'SWEET!!!'
     for i in range(8):
-        app.text("h2", msg[:i])
+        app.text("h2", msg[:i], event['client'])
         await asyncio.sleep(1)
 
-    app.unregister('click', buttonclicked, selector='button')
+    # app.unregister('click', buttonclicked, selector='button')
 
 
 async def clicked(event):
@@ -131,4 +131,4 @@ app.register('init', oninit)
 app.register('load', onload)
 # app.register('click', clicked)
 
-app.start()
+app.start(False)

--- a/sample.py
+++ b/sample.py
@@ -37,10 +37,10 @@ async def oninit(event):
     tb = ButtonToolbar()
     bgrp = ButtonGroup()
     btnDe = Button("Default")
-    btnP = Button("Primary", "primary", ident='clickme')
+    btnP = Button("Primary", "primary", ident='primary')
     btnI = Button("Info", "info")
     bgrp2 = ButtonGroup()
-    btnS = Button("Success", "success")
+    btnS = Button("Success", "success", ident='secondary')
     btnW = Button("Warning", "warning")
     btnDa = Button("Danger", "danger")
 
@@ -89,7 +89,9 @@ async def oninit(event):
 async def onload(event):
     logging.info("LOADED")
 
-    app.register('click', buttonclicked, selector='button')
+    app.register('click', buttonclicked, selector='#primary', client=event['client'])
+    app.register('click', buttonclicked, selector='#secondary', client=event['client'])
+    app.register('click', buttonclicked, selector='#secondary', client=event['client'])
 
     await asyncio.sleep(5)
 
@@ -110,8 +112,6 @@ async def onload(event):
         app.text("h2", msg[:i], event['client'])
         await asyncio.sleep(1)
 
-    # app.unregister('click', buttonclicked, selector='button')
-
 
 async def clicked(event):
     logging.info("CLICKED!")
@@ -123,10 +123,12 @@ async def buttonclicked(event):
     else:
         logging.info("BUTTON " + event['event_object']['target']['innerText'] + " CLICKED!")
 
+    app.unregister('click', buttonclicked, selector='#' + event['event_object']['target']['id'], client=event['client'])
+
 
 logging.basicConfig(format="%(asctime)s [%(levelname)s] - %(funcName)s: %(message)s", level=logging.INFO)
 
-app = Sofi()
+app = Sofi(singleclient=False)
 app.register('init', oninit)
 app.register('load', onload)
 # app.register('click', clicked)

--- a/sofi/app/app.py
+++ b/sofi/app/app.py
@@ -1,169 +1,193 @@
 import asyncio
 import os
-import signal
 
 import json
 import webbrowser
 import logging
 
-from autobahn.asyncio.websocket import WebSocketServerFactory, WebSocketServerProtocol
+from autobahn.asyncio.websocket import WebSocketServerFactory, WebSocketServerProtocol, ConnectionDeny
+
+
+class SofiEventProtocol(WebSocketServerProtocol):
+    """WebSocket / UI event handler instantiated for each connection"""
+
+    def onConnect(self, request):
+        """Triggered when a new WebSocket client (UI layer) attempts to connect"""
+
+        logging.info("Client connecting: %s" % request.peer)
+
+        if self.app.singleclient and len(self.app.clients) == 1:
+            logging.info("Running in Single client mode - extra connection request rejected")
+            raise ConnectionDeny(403)
+
+        self.app.clients.append(self)
+
+    def onOpen(self):
+        """Triggered when a connection is established"""
+
+        logging.info("WebSocket connection open")
+
+    async def onMessage(self, payload, isBinary):
+        """Called whenever a new message is received"""
+
+        if isBinary:
+            logging.info("Binary message received: {} bytes".format(len(payload)))
+        else:
+            logging.info("Text message received: {}".format(payload.decode('utf-8')))
+            body = json.loads(payload.decode('utf-8'))
+
+            if 'event' in body:
+                await self.app.process(self, body)
+                return
+
+    def onClose(self, wasClean, code, reason):
+        """Called when the client closes the connection"""
+
+        logging.info("WebSocket connection closed: {}".format(reason))
+
+        # Exit the application if only listening to one client
+        if self.app.singleclient and self.app.clients[0] == self:
+            # TODO: This should probably be cleaner
+            exit(0)
+
+    def dispatch(self, command):
+        """Send a command to the client / UI layer"""
+
+        self.sendMessage(bytes(json.dumps(command), 'utf-8'), False)
+
 
 class Sofi():
-    def __init__(self):
-        self.interface = SofiEventProcessor()
-        self.server = SofiEventServer(processor=self.interface)
+
+    def __init__(self, singleclient=True, hostname="127.0.0.1", address="0.0.0.0", port=9000, protocol=SofiEventProtocol):
+        # General application configuration info
+        self.hostname = hostname
+        self.address = address
+        self.port = port
+
+        # Protocol class that will manage messaging
+        self.protocol = protocol
+        protocol.app = self
+
+        # Event handlers
+        self.handlers = {
+            'init': {'_': set()},
+            'load': {'_': set()},
+            'close': {'_': set()},
+            'click': {'_': set()},
+            'mousedown': {'_': set()},
+            'mouseup': {'_': set()},
+            'keydown': {'_': set()},
+            'keyup': {'_': set()},
+            'keypress': {'_': set()}
+        }
+
+        # Client management
+        self.clients = list()
+        self.singleclient = singleclient
+
+        # Create the factory that generates protocols to handle socket communications
+        factory = WebSocketServerFactory("ws://" + hostname + ":" + str(port))
+        factory.protocol = protocol
+
+        # Create the Asyncio event loop
+        self.loop = asyncio.get_event_loop()
+
+        # Create the loop server
+        self.server = self.loop.create_server(factory, address, port)
 
     def start(self, autobrowse=True):
         """Start the application"""
 
-        self.server.start(autobrowse)
+        self.loop.run_until_complete(self.server)
 
-    def register(self, event, callback, selector=None):
-        """Register event callback"""
+        try:
+            # Automatically open the browser if requested
+            if autobrowse:
+                path = os.path.dirname(os.path.realpath(__file__))
+                webbrowser.open('file:///' + os.path.join(path, 'main.html'))
 
-        self.interface.register(event, callback, selector)
+            # Start listening for connections
+            self.loop.run_forever()
 
-    def unregister(self, event, callback, selector=None):
-        """Register event callback"""
+        except KeyboardInterrupt:
+            logging.info("Keyboard Interrupt received.")
 
-        self.interface.unregister(event, callback, selector)
+            # Tell any clients that we're closing
+            for client in self.clients:
+                client.sendClose()
+                pass
 
-    def load(self, html, client=None):
-        """Initialize the UI. This will replace the document <html> tag contents with the supplied html."""
+            self.server.close()
 
-        if client is None:
-            client = self.interface
+        finally:
+            # Gather any remaining tasks so we can cancel them
+            asyncio.gather(*asyncio.Task.all_tasks()).cancel()
+            self.loop.stop()
 
-        client.dispatch({ 'name': 'init', 'html': html })
+            logging.info("Cancelling pending tasks...")
+            self.loop.run_forever()
 
-    def append(self, selector, html, client=None):
-        """Append the given html to all elements matching this selector"""
+            logging.info("Stopping Server...")
+            self.loop.close()
 
-        if client is None:
-            client = self.interface
+    def register(self, event, callback, selector=None, client=None):
+        """Register an event callback"""
 
-        client.dispatch({ 'name': 'append', 'selector': selector, 'html': html })
-
-    def remove(self, selector, client=None):
-        """Remove the elements matching this selector."""
-
-        if client is None:
-            client = self.interface
-
-        client.dispatch({ 'name': 'remove', 'selector': selector })
-
-    def replace(self, selector, html, client=None):
-        """Replace the contents all elements matching this selector with the given html."""
-
-        if client is None:
-            client = self.interface
-
-        client.dispatch({ 'name': 'replace', 'selector': selector, 'html': html })
-
-    def addclass(self, selector, cl, client=None):
-        """Add the given class from all elements matching this selector."""
-
-        if client is None:
-            client = self.interface
-
-        client.dispatch({ 'name': 'addclass', 'selector': selector, 'cl': cl })
-
-    def removeclass(self, selector, cl, client=None):
-        """Remove the given class from all elements matching this selector."""
-
-        if client is None:
-            client = self.interface
-
-        client.dispatch({ 'name': 'removeclass', 'selector': selector, 'cl': cl })
-
-    def text(self, selector, text, client=None):
-        """Set the text for elements matching the selector."""
-
-        if client is None:
-            client = self.interface
-
-        client.dispatch({ 'name': 'text', 'selector': selector, 'text': text })
-
-    def attr(self, selector, attr, value, client=None):
-        """Set the attribute for elements matching this selector."""
-
-        if client is None:
-            client = self.interface
-
-        client.dispatch({ 'name': 'attr', 'selector': selector, 'attr': attr, 'value': value })
-
-    def style(self, selector, style, value, priority=None, client=None):
-        """Set the style for elements matching this selector. The priority field can be set to "important" to force the style."""
-
-        if client is None:
-            client = self.interface
-
-        client.dispatch({ 'name': 'style', 'selector': selector, 'style': style, 'value': value, 'priority': priority })
-
-    def property(self, selector, property, value, client=None):
-        """Set the property for elements matching this selector. Properties are special attributes like 'checked' or 'value'."""
-
-        if client is None:
-            client = self.interface
-
-        client.dispatch({ 'name': 'attr', 'selector': selector, 'property': property, 'value': value })
-
-
-class SofiEventProcessor():
-    """Event handler providing hooks for callback functions"""
-
-    handlers = { 'init': { '_': [] },
-                 'load': { '_': [] },
-                 'close': { '_': [] },
-                 'click': { '_': [] },
-                 'mousedown': { '_': [] },
-                 'mouseup': { '_': [] },
-                 'keydown': { '_': [] },
-                 'keyup': { '_': [] },
-                 'keypress': { '_': [] }
-               }
-
-    def register(self, event, callback, selector=None):
+        # If we didn't know of this event, add it to the handler mappings
         if event not in self.handlers:
-            self.handlers[event] = { '_': [] }
+            self.handlers[event] = {'_': list()}
 
-        if selector:
-            key = str(id(callback))
-        else:
+        capture = False
+        if selector is None:
             key = '_'
+            selector = 'html'
+            capture = True
+        else:
+            key = str(id(callback)) + selector
 
         if key not in self.handlers[event]:
-            self.handlers[event][key] = list()
+            self.handlers[event][key] = set()
 
-        self.handlers[event][key].append(callback)
+        self.handlers[event][key].add(callback)
 
         if event not in ('init', 'load', 'close') and len(self.handlers[event].keys()) > 1:
-            capture = False
-            if selector is None:
-                selector = 'html'
-                capture = True
+            if self.singleclient or client is None:
+                client = self.clients[0]
 
-            self.dispatch({ 'name': 'subscribe', 'event': event, 'selector': selector, 'capture': capture, 'key': str(id(callback)) })
+            # Tell the UI layer to subscribe to this event
+            client.dispatch({'name': 'subscribe', 'event': event, 'selector': selector, 'capture': capture, 'key': str(id(callback)) + selector})
 
-    def unregister(self, event, callback, selector=None):
+    def unregister(self, event, callback, selector=None, client=None):
+        """Remove an event callback"""
+
         if event not in self.handlers:
             return
 
         if selector is None:
             self.handlers[event]['_'].remove(callback)
         else:
-            handler_list = self.handlers[event].get(str(id(callback)), [])
+            handler_list = self.handlers[event].get(str(id(callback)) + selector, set())
             if callback in handler_list:
                 handler_list.remove(callback)
 
         if event not in ('init', 'load', 'close'):
-            self.dispatch({ 'name': 'unsubscribe', 'event': event, 'selector': selector, 'key': str(id(callback)) })
+            if self.singleclient or client is None:
+                client = self.clients[0]
+
+            # Tell the UI layer to unsubscribe from this event
+            client.dispatch({'name': 'unsubscribe', 'event': event, 'selector': selector, 'key': str(id(callback)) + selector})
 
     def dispatch(self, command):
-        self.protocol.dispatch(command)
+        """Send a command to the UI layer. Only use in singleclient mode"""
+
+        if self.singleclient:
+            self.clients[0].dispatch(command)
+        else:
+            raise NotImplementedError("Using Sofi.dispatch with more than one client can have unintended consequences and is not supported")
 
     async def process(self, protocol, event):
-        self.protocol = protocol
+        """Process a new event"""
+
         eventtype = event['event']
         event['client'] = protocol
 
@@ -173,86 +197,91 @@ class SofiEventProcessor():
                 key = event['key']
 
                 if key in self.handlers[eventtype]:
-                    for handler in self.handlers[eventtype][key]:
+                    for handler in list(self.handlers[eventtype][key]):
                         if callable(handler):
                             await handler(event)
 
             # Check for global handler
-            for handler in self.handlers[eventtype]['_']:
+            for handler in list(self.handlers[eventtype]['_']):
                 if callable(handler):
                     await handler(event)
 
+    def load(self, html, client=None):
+        """Initialize the UI. This will replace the document <html> tag contents with the supplied html."""
 
-class SofiEventProtocol(WebSocketServerProtocol):
-    """Websocket event handler which dispatches events to SofiEventProcessor"""
+        if client is None:
+            client = self.clients[0]
 
-    def onConnect(self, request):
-        logging.info("Client connecting: %s" % request.peer)
+        client.dispatch({'name': 'init', 'html': html})
 
-    def onOpen(self):
-        logging.info("WebSocket connection open")
+    def append(self, selector, html, client=None):
+        """Append the given html to all elements matching this selector"""
 
-    async def onMessage(self, payload, isBinary):
-        if isBinary:
-            logging.info("Binary message received: {} bytes".format(len(payload)))
-        else:
-            logging.info("Text message received: {}".format(payload.decode('utf-8')))
-            body = json.loads(payload.decode('utf-8'))
+        if client is None:
+            client = self.clients[0]
 
-            if 'event' in body:
-                await self.processor.process(self, body)
-                return
+        client.dispatch({'name': 'append', 'selector': selector, 'html': html})
 
-    def onClose(self, wasClean, code, reason):
-        logging.info("WebSocket connection closed: {}".format(reason))
-        exit(0)
+    def remove(self, selector, client=None):
+        """Remove the elements matching this selector."""
 
-    def dispatch(self, command):
-        self.sendMessage(bytes(json.dumps(command), 'utf-8'), False)
+        if client is None:
+            client = self.clients[0]
 
+        client.dispatch({'name': 'remove', 'selector': selector})
 
-class SofiEventServer():
-    """Websocket event server"""
+    def replace(self, selector, html, client=None):
+        """Replace the contents all elements matching this selector with the given html."""
 
-    def __init__(self, hostname=u"127.0.0.1", port=9000, processor=None):
+        if client is None:
+            client = self.clients[0]
 
-        self.hostname = hostname
-        self.port = port
-        self.processor = processor
+        client.dispatch({'name': 'replace', 'selector': selector, 'html': html})
 
-        factory = WebSocketServerFactory(u"ws://" + hostname + u":" + str(port))
-        protocol = SofiEventProtocol
-        protocol.processor = processor
-        protocol.app = self
+    def addclass(self, selector, cl, client=None):
+        """Add the given class from all elements matching this selector."""
 
-        factory.protocol = protocol
+        if client is None:
+            client = self.clients[0]
 
-        self.loop = asyncio.get_event_loop()
-        self.server = self.loop.create_server(factory, '0.0.0.0', port)
+        client.dispatch({'name': 'addclass', 'selector': selector, 'cl': cl})
 
-    def start(self, autobrowse=True):
-        self.loop.run_until_complete(self.server)
+    def removeclass(self, selector, cl, client=None):
+        """Remove the given class from all elements matching this selector."""
 
-        try:
-            path = os.path.dirname(os.path.realpath(__file__))
-            if autobrowse:
-                webbrowser.open('file:///' + os.path.join(path, 'main.html'))
-            self.loop.run_forever()
+        if client is None:
+            client = self.clients[0]
 
-        except KeyboardInterrupt:
-            logging.info("Keyboard Interrupt received.")
-            self.server.close()
+        client.dispatch({'name': 'removeclass', 'selector': selector, 'cl': cl})
 
-        finally:
-            asyncio.gather(*asyncio.Task.all_tasks()).cancel()
-            self.loop.stop()
-            logging.info("Cancelling pending tasks...")
-            self.loop.run_forever()
-            logging.info("Stopping Server...")
-            self.loop.close()
+    def text(self, selector, text, client=None):
+        """Set the text for elements matching the selector."""
 
-    def __repr__(self):
-        return "<SofiEventServer(%s, %s)>" % (self.hostname, self.port)
+        if client is None:
+            client = self.clients[0]
 
-    def __str__(self):
-        return repr(self)
+        client.dispatch({'name': 'text', 'selector': selector, 'text': text})
+
+    def attr(self, selector, attr, value, client=None):
+        """Set the attribute for elements matching this selector."""
+
+        if client is None:
+            client = self.clients[0]
+
+        client.dispatch({'name': 'attr', 'selector': selector, 'attr': attr, 'value': value})
+
+    def style(self, selector, style, value, priority=None, client=None):
+        """Set the style for elements matching this selector. The priority field can be set to "important" to force the style."""
+
+        if client is None:
+            client = self.clients[0]
+
+        client.dispatch({'name': 'style', 'selector': selector, 'style': style, 'value': value, 'priority': priority})
+
+    def property(self, selector, property, value, client=None):
+        """Set the property for elements matching this selector. Properties are special attributes like 'checked' or 'value'."""
+
+        if client is None:
+            client = self.clients[0]
+
+        client.dispatch({'name': 'attr', 'selector': selector, 'property': property, 'value': value})

--- a/sofi/app/app.py
+++ b/sofi/app/app.py
@@ -135,7 +135,7 @@ class Sofi():
 
         # If we didn't know of this event, add it to the handler mappings
         if event not in self.handlers:
-            self.handlers[event] = {'_': list()}
+            self.handlers[event] = {'_': set()}
 
         capture = False
         if selector is None:

--- a/sofi/app/sofi.js
+++ b/sofi/app/sofi.js
@@ -1,4 +1,3 @@
-
 var SOCKET_URL = "ws://127.0.0.1:9000"
 var socket
 
@@ -48,7 +47,7 @@ function init() {
                 d3.selectAll(command.selector).style(command.style, command.value, command.priority)
             }
             else {
-                d3.selectAll(command.selector).style(command.style, command.value)    
+                d3.selectAll(command.selector).style(command.style, command.value)
             }
         }
         else if (command.name == "property") {


### PR DESCRIPTION
Polished multi-clients mode and code cleanup
* Consolidated `sofi.app` classes into `SofiEventProtocol` and `Sofi`.
* Removed `Sofi.interface` and folded its methods into the main `Sofi`
  class.
* Added `singleclient` parameter when instantiating `Sofi` to restrict
  use to one user interface. It will reject any connection requests
  after the first one.
* All command dispatch methods now take a `client` keyword parameter
  to specify which UI client they will be sent to.
* The client that initiated an event is added to the `event` dict
  passed to every event function and should be used in any dispatch
  methods called from that function.
* The event callback registry now uses sets instead of lists to prevent
  the same callback being registered twice for the same exact event.
* `Sofi.clients` keeps track of all connected UI clients.